### PR TITLE
Add optional desktop notifications

### DIFF
--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -66,18 +66,19 @@ done
 restic unlock &
 wait $!
 
-# Do the backup!
+# Do the backup! (and capture the output for further processing)
 # See restic-backup(1) or http://restic.readthedocs.io/en/latest/040_backup.html
 # --one-file-system makes sure we only backup exactly those mounted file systems specified in $RESTIC_BACKUP_PATHS, and thus not directories like /dev, /sys etc.
 # --tag lets us reference these backups later when doing restic-forget.
-{ backup_output=$(restic backup \
-	--verbose="$RESTIC_VERBOSITY_LEVEL" \
-	--one-file-system \
-	--tag "$RESTIC_BACKUP_TAG" \
-	--option b2.connections="$B2_CONNECTIONS" \
-	"${exclusion_args[@]}" \
-	"${extra_args[@]}" \
-	"${backup_paths[@]}" \
+{ backup_output=$( \
+	restic backup \
+		--verbose="$RESTIC_VERBOSITY_LEVEL" \
+		--one-file-system \
+		--tag "$RESTIC_BACKUP_TAG" \
+		--option b2.connections="$B2_CONNECTIONS" \
+		"${exclusion_args[@]}" \
+		"${extra_args[@]}" \
+		"${backup_paths[@]}" \
 	| tee /dev/fd/3 & )  # store output in var for further proc; also tee to a temp fd that's redirected to stdout
 } 3>&1
 wait $!

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -70,14 +70,16 @@ wait $!
 # See restic-backup(1) or http://restic.readthedocs.io/en/latest/040_backup.html
 # --one-file-system makes sure we only backup exactly those mounted file systems specified in $RESTIC_BACKUP_PATHS, and thus not directories like /dev, /sys etc.
 # --tag lets us reference these backups later when doing restic-forget.
-restic backup \
+{ backup_output=$(restic backup \
 	--verbose="$RESTIC_VERBOSITY_LEVEL" \
 	--one-file-system \
 	--tag "$RESTIC_BACKUP_TAG" \
 	--option b2.connections="$B2_CONNECTIONS" \
 	"${exclusion_args[@]}" \
 	"${extra_args[@]}" \
-	"${backup_paths[@]}" &
+	"${backup_paths[@]}" \
+	| tee /dev/fd/3 & )  # store output in var for further proc; also tee to a temp fd that's redirected to stdout
+} 3>&1
 wait $!
 
 # Dereference and delete/prune old backups.
@@ -101,3 +103,31 @@ wait $!
 #wait $!
 
 echo "Backup & cleaning is done."
+
+#
+# (optionally) Notify about backup summary stats.
+#
+# How to perform the notification is up to the user; the script only writes the info to the user-owned file in a fire
+# and forget fashion.
+#
+# One option to trigger desktop notifications on user-side is using a special FIFO file (a.k.a. pipe file), which will
+# work as a queue; plus, a user process to read from that queue and run a desktop notification command.
+#
+# TODO Clean/or rephrase the example comments below
+# In this case I'm running a user process that reads from a special pipe file and sends a desktop notification using
+# `notify-send`.
+# 
+# See: https://github.com/gerardbosch/dotfiles-linux/blob/main/home/.config/autostart/notification-queue.desktop and
+#      https://github.com/gerardbosch/dotfiles-linux/blob/main/home/bin/notification-queue-start-processing
+#
+if [ "$RESTIC_NOTIFY_BACKUP_STATS" = true ]; then
+	if [ -w "$RESTIC_BACKUP_NOTIFICATION_FILE" ]; then
+		added=$(grep -i 'Added to the repo:' <<< "$backup_output" | sed -E 's/.*dded to the repo: (.*)/\1/')
+		# sample:  processed N files, N.XYZ GiB in H:mm
+		size=$(grep  -i 'processed.*files,'  <<< "$backup_output" | sed -E 's/.*rocessed.*files, (.*) in.*/\1/g')
+		echo "Added: ${added}. Snapshot size: ${size}" >> "$RESTIC_BACKUP_NOTIFICATION_FILE"
+	else
+		echo "[WARN] Couldn't write the backup summary stats. File not found or not writable: ${RESTIC_BACKUP_NOTIFICATION_FILE}"
+	fi
+fi
+

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -105,18 +105,17 @@ echo "Backup & cleaning is done."
 #
 # (optionally) Notify about backup summary stats.
 #
-# How to perform the notification is up to the user; the script only writes the info to the user-owned file in a fire
-# and forget fashion.
+# How to perform the notification is up to the user; the script only writes the info to a user-owned file in a fire
+# and forget fashion. One option is using a special FIFO file (aka pipe file) on user-side (which will work as a queue)
+# together with an auto-started user process to read from that queue and trigger the notification.
 #
-# One option to trigger desktop notifications on user-side is using a special FIFO file (a.k.a. pipe file), which will
-# work as a queue; plus, a user process to read from that queue and run a desktop notification command.
-#
-# TODO Clean/or rephrase the example comments below
-# In this case I'm running a user process that reads from a special pipe file and sends a desktop notification using
-# `notify-send`.
-#
-# See: https://github.com/gerardbosch/dotfiles-linux/blob/main/home/.config/autostart/notification-queue.desktop and
-#      https://github.com/gerardbosch/dotfiles-linux/blob/main/home/bin/notification-queue-start-processing
+# Examples of such setup:
+#   - Linux autostart + cross-platform notifier
+#       https://github.com/gerardbosch/dotfiles-linux/blob/ea0f75bfd7a356945544ecaa42a2fc35c9fab3a1/home/.config/autostart/notification-queue.desktop
+#       https://github.com/gerardbosch/dotfiles/blob/ddc1491056822eab45dedd131f1946308ef62135/home/bin/notification-queue-notifier
+#   - MacOS autostart + terminal-notifier
+#       https://github.com/erikw/dotfiles/blob/c25f44db1cad675becf91fc3ff28a5a4dfc4a373/bin/com.user.notificationqueue.plist
+#       https://github.com/erikw/dotfiles/blob/c25f44db1cad675becf91fc3ff28a5a4dfc4a373/bin/notification-queue-notifier.sh
 #
 if [ "$RESTIC_NOTIFY_BACKUP_STATS" = true ]; then
 	if [ -w "$RESTIC_BACKUP_NOTIFICATION_FILE" ]; then

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -116,18 +116,17 @@ echo "Backup & cleaning is done."
 # TODO Clean/or rephrase the example comments below
 # In this case I'm running a user process that reads from a special pipe file and sends a desktop notification using
 # `notify-send`.
-# 
+#
 # See: https://github.com/gerardbosch/dotfiles-linux/blob/main/home/.config/autostart/notification-queue.desktop and
 #      https://github.com/gerardbosch/dotfiles-linux/blob/main/home/bin/notification-queue-start-processing
 #
 if [ "$RESTIC_NOTIFY_BACKUP_STATS" = true ]; then
 	if [ -w "$RESTIC_BACKUP_NOTIFICATION_FILE" ]; then
-		added=$(grep -i 'Added to the repo:' <<< "$backup_output" | sed -E 's/.*dded to the repo: (.*)/\1/')
+		added=$(echo "$backup_output" | grep -i 'Added to the repo:' | sed -E 's/.*dded to the repo: (.*)/\1/')
 		# sample:  processed N files, N.XYZ GiB in H:mm
-		size=$(grep  -i 'processed.*files,'  <<< "$backup_output" | sed -E 's/.*rocessed.*files, (.*) in.*/\1/g')
+		size=$(echo "$backup_output" | grep  -i 'processed.*files,' | sed -E 's/.*rocessed.*files, (.*) in.*/\1/g')
 		echo "Added: ${added}. Snapshot size: ${size}" >> "$RESTIC_BACKUP_NOTIFICATION_FILE"
 	else
 		echo "[WARN] Couldn't write the backup summary stats. File not found or not writable: ${RESTIC_BACKUP_NOTIFICATION_FILE}"
 	fi
 fi
-

--- a/etc/restic/_global.env.sh
+++ b/etc/restic/_global.env.sh
@@ -29,3 +29,8 @@ export RESTIC_BACKUP_EXTRA_ARGS=
 # Verbosity level from 0-3. 0 means no --verbose.
 # Override this value in a profile if needed.
 export RESTIC_VERBOSITY_LEVEL=0
+
+# (optional) Desktop notifications
+export RESTIC_NOTIFY_BACKUP_STATS="false"
+export RESTIC_BACKUP_NOTIFICATION_FILE=""
+

--- a/etc/restic/_global.env.sh
+++ b/etc/restic/_global.env.sh
@@ -30,7 +30,6 @@ export RESTIC_BACKUP_EXTRA_ARGS=
 # Override this value in a profile if needed.
 export RESTIC_VERBOSITY_LEVEL=0
 
-# (optional) Desktop notifications
+# (optional) Desktop notifications. See restic_backup.sh for details on how to set this up.
 export RESTIC_NOTIFY_BACKUP_STATS="false"
 export RESTIC_BACKUP_NOTIFICATION_FILE=""
-


### PR DESCRIPTION
When backing up a desktop system it is handy to have regular and
immediate feedback about backups. This features a notification of backup
stats summary, including the added size to the repository, so you can
have a quick follow-up about what are you uploading to the repository.

This may be very useful if you upload by accident a big file or directory
which should be in your exclusions, so it warns you and gives the chance
to fix the exclusions and remove the undesired snapshot later.