### PR TITLE
Fix README/resticw commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Useful commands:
 | Command                                           | Description                                                       |
 |---------------------------------------------------|-------------------------------------------------------------------|
 | `resticw snapshots`                               | List backup snapshots                                             |
-| `resticw diff <snapshotId-1> <snapshotId-2>`      | Show the changes from the latest backup                           |
+| `resticw diff <snapshotId-1> <snapshotId-2>`      | Show the changes between backup snapshots                         |
 | `resticw stats` / `resticw stats snapshotId ...`  | Show the statistics for the whole repo or the specified snapshots |
 | `resticw mount /mnt/restic`                       | Mount your remote repository                                      |
 

--- a/README.md
+++ b/README.md
@@ -517,8 +517,8 @@ Useful commands:
 | Command                                           | Description                                                       |
 |---------------------------------------------------|-------------------------------------------------------------------|
 | `resticw snapshots`                               | List backup snapshots                                             |
-| `resticw diff <snapshot-id> latest`               | Show the changes from the latest backup                           |
-| `resticw stats` / `resticw stats snapshot-id ...` | Show the statistics for the whole repo or the specified snapshots |
+| `resticw diff <snapshotId-1> <snapshotId-2>`      | Show the changes from the latest backup                           |
+| `resticw stats` / `resticw stats snapshotId ...`  | Show the statistics for the whole repo or the specified snapshots |
 | `resticw mount /mnt/restic`                       | Mount your remote repository                                      |
 
 


### PR DESCRIPTION
As per restic 0.12.1, the special snapshot ID `latest` is not supported by `diff` command.