### PR TITLE
Add support saving hourly snapshots

### DIFF
--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -93,6 +93,7 @@ restic forget \
 	--option b2.connections="$B2_CONNECTIONS" \
 	--prune \
 	--group-by "paths,tags" \
+	--keep-hourly "$RESTIC_RETENTION_HOURS" \  
 	--keep-daily "$RESTIC_RETENTION_DAYS" \
 	--keep-weekly "$RESTIC_RETENTION_WEEKS" \
 	--keep-monthly "$RESTIC_RETENTION_MONTHS" \

--- a/etc/restic/default.env.sh
+++ b/etc/restic/default.env.sh
@@ -32,6 +32,7 @@ export RESTIC_BACKUP_TAG=systemd.timer
 
 # Retention policy - How many backups to keep.
 # See https://restic.readthedocs.io/en/stable/060_forget.html?highlight=month#removing-snapshots-according-to-a-policy
+export RESTIC_RETENTION_HOURS=1
 export RESTIC_RETENTION_DAYS=14
 export RESTIC_RETENTION_WEEKS=16
 export RESTIC_RETENTION_MONTHS=18


### PR DESCRIPTION
Not certain why it's not set by default, but think it would be pretty common to ant to keep an hourly copy of your snapshots? Not major PR and people can make the change themselves (as always done) but maybe some don't know they can run it more often than daily and keep hourly snapshots too.