### PR TITLE
Allow extra args for non-backup commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Support for extra args for all restic commands with `RESTIC_EXTRA_ARGS`. [115](https://github.com/erikw/restic-automatic-backup-scheduler/pull/115/)
 ### Changed
 - Warn on certain unset envvars instead of error-exit.
 - Allow escaped spaces in EXTRA_ARGS.

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -8,8 +8,9 @@
 #   $ source $PREFIX/etc/default.env.sh
 #   $ restic_backup.sh
 
-# Exit on error, unset var, pipe failure
-set -eo pipefail
+set -o errexit
+set -o pipefail
+[[ "${TRACE-0}" =~ ^1|t|y|true|yes$ ]] && set -o xtrace
 
 # Clean up lock if we are killed.
 # If killed by systemd, like $(systemctl stop restic), then it kills the whole cgroup and all it's subprocesses.
@@ -49,13 +50,13 @@ warn_on_missing_envvars() {
 }
 
 assert_envvars \
-	RESTIC_BACKUP_PATHS RESTIC_BACKUP_TAG \
-	RESTIC_BACKUP_EXCLUDE_FILE RESTIC_BACKUP_EXTRA_ARGS RESTIC_REPOSITORY RESTIC_VERBOSITY_LEVEL \
-	RESTIC_RETENTION_HOURS RESTIC_RETENTION_DAYS RESTIC_RETENTION_MONTHS RESTIC_RETENTION_WEEKS RESTIC_RETENTION_YEARS
+    RESTIC_BACKUP_PATHS RESTIC_BACKUP_TAG \
+    RESTIC_BACKUP_EXCLUDE_FILE RESTIC_BACKUP_EXTRA_ARGS RESTIC_REPOSITORY RESTIC_VERBOSITY_LEVEL \
+    RESTIC_RETENTION_HOURS RESTIC_RETENTION_DAYS RESTIC_RETENTION_MONTHS RESTIC_RETENTION_WEEKS RESTIC_RETENTION_YEARS
 
 warn_on_missing_envvars \
-	B2_ACCOUNT_ID B2_ACCOUNT_KEY B2_CONNECTIONS \
-	RESTIC_PASSWORD_FILE
+    B2_ACCOUNT_ID B2_ACCOUNT_KEY B2_CONNECTIONS \
+    RESTIC_PASSWORD_FILE
 
 # Convert to arrays, as arrays should be used to build command lines. See https://github.com/koalaman/shellcheck/wiki/SC2086
 IFS=':' read -ra backup_paths <<< "$RESTIC_BACKUP_PATHS"
@@ -64,6 +65,11 @@ IFS=':' read -ra backup_paths <<< "$RESTIC_BACKUP_PATHS"
 extra_args=( )
 while IFS= read -r -d ''; do
   extra_args+=( "$REPLY" )
+done < <(xargs printf '%s\0' <<<"$RESTIC_EXTRA_ARGS")
+
+backup_extra_args=( )
+while IFS= read -r -d ''; do
+  backup_extra_args+=( "$REPLY" )
 done < <(xargs printf '%s\0' <<<"$RESTIC_BACKUP_EXTRA_ARGS")
 
 B2_ARG=
@@ -95,7 +101,8 @@ test "$OSTYPE" = msys || FS_ARG=--one-file-system
 # Reference: https://unix.stackexchange.com/questions/146756/forward-sigterm-to-child-in-bash
 
 # Remove locks from other stale processes to keep the automated backup running.
-restic unlock &
+restic unlock \
+	"${extra_args[@]}" &
 wait $!
 
 # Do the backup!
@@ -108,7 +115,7 @@ restic backup \
 	--tag "$RESTIC_BACKUP_TAG" \
 	"${B2_ARG[@]}" \
 	"${exclusion_args[@]}" \
-	"${extra_args[@]}" \
+	"${backup_extra_args[@]}" \
 	"${backup_paths[@]}" &
 wait $!
 
@@ -119,6 +126,7 @@ restic forget \
 	--verbose="$RESTIC_VERBOSITY_LEVEL" \
 	--tag "$RESTIC_BACKUP_TAG" \
 	"${B2_ARG[@]}" \
+	"${extra_args[@]}" \
 	--prune \
 	--group-by "paths,tags" \
 	--keep-hourly "$RESTIC_RETENTION_HOURS" \
@@ -140,13 +148,13 @@ if [ "$RESTIC_NOTIFY_BACKUP_STATS" = true ]; then
 	if [ -w "$RESTIC_BACKUP_NOTIFICATION_FILE" ]; then
 		echo 'Notifications are enabled: Silently computing backup summary stats...'
 
-		snapshot_size=$(restic stats latest --tag "$RESTIC_BACKUP_TAG" | grep -i 'total size:' | cut -d ':' -f2 | xargs)  # xargs acts as trim
-		latest_snapshot_diff=$(restic snapshots --tag "$RESTIC_BACKUP_TAG" --latest 2 --compact \
+		snapshot_size=$(restic stats latest --tag "$RESTIC_BACKUP_TAG" "${extra_args[@]}" | grep -i 'total size:' | cut -d ':' -f2 | xargs)  # xargs acts as trim
+		latest_snapshot_diff=$(restic snapshots --tag "$RESTIC_BACKUP_TAG" --latest 2 --compact "${extra_args[@]}" \
 			| grep -Ei "^[abcdef0-9]{8} " \
 			| awk '{print $1}' \
 			| tail -2 \
 			| tr '\n' ' ' \
-			| xargs restic diff)
+			| xargs restic diff "${extra_args[@]}")
         added=$(echo "$latest_snapshot_diff" | grep -i 'added:' | awk '{print $2 " " $3}')
         removed=$(echo "$latest_snapshot_diff" | grep -i 'removed:' | awk '{print $2 " " $3}')
 

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -50,13 +50,13 @@ warn_on_missing_envvars() {
 }
 
 assert_envvars \
-    RESTIC_BACKUP_PATHS RESTIC_BACKUP_TAG \
-    RESTIC_BACKUP_EXCLUDE_FILE RESTIC_BACKUP_EXTRA_ARGS RESTIC_REPOSITORY RESTIC_VERBOSITY_LEVEL \
-    RESTIC_RETENTION_HOURS RESTIC_RETENTION_DAYS RESTIC_RETENTION_MONTHS RESTIC_RETENTION_WEEKS RESTIC_RETENTION_YEARS
+	RESTIC_BACKUP_PATHS RESTIC_BACKUP_TAG \
+	RESTIC_BACKUP_EXCLUDE_FILE RESTIC_BACKUP_EXTRA_ARGS RESTIC_REPOSITORY RESTIC_VERBOSITY_LEVEL \
+	RESTIC_RETENTION_HOURS RESTIC_RETENTION_DAYS RESTIC_RETENTION_MONTHS RESTIC_RETENTION_WEEKS RESTIC_RETENTION_YEARS
 
 warn_on_missing_envvars \
-    B2_ACCOUNT_ID B2_ACCOUNT_KEY B2_CONNECTIONS \
-    RESTIC_PASSWORD_FILE
+	B2_ACCOUNT_ID B2_ACCOUNT_KEY B2_CONNECTIONS \
+	RESTIC_PASSWORD_FILE
 
 # Convert to arrays, as arrays should be used to build command lines. See https://github.com/koalaman/shellcheck/wiki/SC2086
 IFS=':' read -ra backup_paths <<< "$RESTIC_BACKUP_PATHS"
@@ -64,12 +64,12 @@ IFS=':' read -ra backup_paths <<< "$RESTIC_BACKUP_PATHS"
 # Convert to array, an preserve spaces. See #111
 extra_args=( )
 while IFS= read -r -d ''; do
-  extra_args+=( "$REPLY" )
+	extra_args+=( "$REPLY" )
 done < <(xargs printf '%s\0' <<<"$RESTIC_EXTRA_ARGS")
 
 backup_extra_args=( )
 while IFS= read -r -d ''; do
-  backup_extra_args+=( "$REPLY" )
+	backup_extra_args+=( "$REPLY" )
 done < <(xargs printf '%s\0' <<<"$RESTIC_BACKUP_EXTRA_ARGS")
 
 B2_ARG=

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -8,9 +8,8 @@
 #   $ source $PREFIX/etc/default.env.sh
 #   $ restic_backup.sh
 
-set -o errexit
-set -o pipefail
-[[ "${TRACE-0}" =~ ^1|t|y|true|yes$ ]] && set -o xtrace
+# Exit on error, unset var, pipe failure
+set -eo pipefail
 
 # Clean up lock if we are killed.
 # If killed by systemd, like $(systemctl stop restic), then it kills the whole cgroup and all it's subprocesses.

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -115,6 +115,7 @@ restic backup \
 	--tag "$RESTIC_BACKUP_TAG" \
 	"${B2_ARG[@]}" \
 	"${exclusion_args[@]}" \
+	"${extra_args[@]}" \
 	"${backup_extra_args[@]}" \
 	"${backup_paths[@]}" &
 wait $!

--- a/etc/restic/default.env.sh
+++ b/etc/restic/default.env.sh
@@ -43,3 +43,10 @@ export RESTIC_RETENTION_YEARS=3
 #RESTIC_BACKUP_EXTRA_ARGS="--exclude-file /path/to/extra/exclude/file/a --exclude-file /path/to/extra/exclude/file/b"
 # Example: exclude all directories that have a .git/ directory inside it.
 #RESTIC_BACKUP_EXTRA_ARGS="--exclude-if-present .git"
+
+# Optional extra space-separated arguments to all restic commands, i.e. global arguments.
+# Example: Limit download speed to a maximum of 1000 KiB/s
+#RESTIC_EXTRA_ARGS="--limit-download 1000"
+# Example: Set custom sftp parameters or a custom path.
+#RESTIC_EXTRA_ARGS="--option sftp.command='ssh\ backup-host\ -s\ sftp'"
+


### PR DESCRIPTION
Add the env variable `RESTIC_EXTRA_ARGS` that will be added to _all_ `restic` commands, including `restic stats` etc. This can be used for additional setting for accessing the repo (like the sftp binary setting).