### PR TITLE
Fix README systemd email notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,10 +476,10 @@ We want to be aware when the automatic backup fails, so we can fix it. Since my 
 Put this file in `/bin`:
 * `systemd-email`: Sends email using sendmail(1). This script also features time-out for not spamming Gmail servers and getting my account blocked.
 
-Put this files in `/etc/systemd/system/`:
-* `status-email-user@.service`: A service that can notify you via email when a systemd service fails. Edit the target email address in this file.
+Put this file in `/etc/systemd/system/`:
+* `status-email-user@.service`: A service that can notify you via email when a systemd service fails. Edit the target email address in this file and remove `$INSTALL_PREFIX` from `ExecStart` line if needed.
 
-Now edit `restic-backup@.service` and `status-email-user@.service` to call this service failure.
+Now edit `restic-backup@.service` and `restic-check@.service` at `/usr/lib/systemd/system/`, under `[Unit]`, to call this service failure:
 ```
 OnFailure=status-email-user@%n.service
 ```

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ $ git clone https://github.com/erikw/restic-automatic-backup-scheduler.git && cd
 
 Make a quick search-and-replace in the source files:
 ```console
-$ find etc bin -type f -exec sed -i.bak -e 's|$INSTALL_PREFIX||g' {} \; -exec rm {}.bak \;
+$ find etc bin usr -type f -exec sed -i.bak -e 's|$INSTALL_PREFIX||g' {} \; -exec rm {}.bak \;
 ```
 and you should now see that all files have been changed like e.g.
 ```diff


### PR DESCRIPTION
Hello, thanks for your works that allow me to do scheduled backups with restic.
This are just minor fixes in the README, about systemd email notification.

I was getting this error, because `$INSTALL_PREFIX` was still there even if I installed it via `make`:
```
Failed to enqueue OnFailure= job, ignoring: Unit status-email-user@restic-check@default.service.service has a bad unit file setting.
```
Removing fixed it.
HTH