### PR TITLE
feat: Log the backup stats summary to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,12 @@ To create a different backup and use you can do:
 # restic_backup.sh
 ```
 
+### Optional (enabled): Summary stats log
+
+Enabled by default but can be disabled (opt-out) by setting its env variable empty: `RESTIC_BACKUP_STATS_DIR=` either on a specific profile, or on the global environment file (default: `$INSTALL_PREFIX/var/log/restic-automatic-backup-scheduler/`).
+
+The stats log (as well as) the desktop notifications incur in an additional run of `restic snapshots` and `restic diff`. This execution is shared with the notifications (no extra run).
+
 ### Optional: Desktop Notifications
 <img src="img/macos_notification.png" align="right" />
 

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@
 # Intro
 [restic](https://restic.net/) is a command-line tool for making backups, the right way. Check the official website for a feature explanation. As a storage backend, I recommend [Backblaze B2](https://www.backblaze.com/b2/cloud-storage.html) as restic works well with it, and it is (at the time of writing) very affordable for the hobbyist hacker! (anecdotal: I pay for my full-systems backups each month typically < 1 USD).
 
-Unfortunately restic does not come pre-configured with a way to run automated backups, say every day. However it's possible to set this up yourself using built-in tools in your OS and some wrappers. For Linux with systemd, it's convenient to use systemd timers. For macOS systems, we can use built-in LaunchAgents. For Windows we can use ScheduledTasks. Any OS having something cron-like will also work!
+Unfortunately restic does not come pre-configured with a way to run automated backups, say every day. However, it's possible to set this up yourself using built-in tools in your OS and some wrappers. For Linux with systemd, it's convenient to use systemd timers. For macOS systems, we can use built-in LaunchAgents. For Windows we can use ScheduledTasks. Any OS having something cron-like will also work!
 
 Here follows a step-by step tutorial on how to set it up, with my sample script and configurations that you can modify to suit your needs.
 
-Note, you can use any restic's supported [storage backends](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html). The setup should be similar but you will have to use other configuration variables to match your backend of choice.
+Note, you can use any restic's supported [storage backends](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html). The setup should be similar, but you will have to use other configuration variables to match your backend of choice.
 
 ## Project Scope
 The scope for this is not to be a full-fledged super solution that solves all the problems and all possible setups. The aim is to be a hackable code base for you to start sewing up the perfect backup solution that fits your requirements!
 
-Nevertheless the project should work out of the box, be minimal but still open the doors for configuration and extensions by users.
+Nevertheless, the project should work out of the box, be minimal but still open the doors for configuration and extensions by users.
 
 To use a different storage backend than B2, you should only need to tweak a few settings variables in the backup profile as well as some restic arguments inside `restic_backup.sh`.
 
@@ -445,9 +445,9 @@ To create a different backup and use you can do:
 ### Optional: Desktop Notifications
 <img src="img/macos_notification.png" align="right" />
 
-It's a good idea to be on top of your backups to make sure that they don't increase a lot in size and incur high costs. However it's notoriously tricky to make GUI notifications correctly from a non-user process (e.g. root).
+It's a good idea to be on top of your backups to make sure that they don't increase a lot in size and incur high costs. However, it's notoriously tricky to make GUI notifications correctly from a non-user process (e.g. root).
 
-Therefore this project provides a lightweight solution for desktop notifications that works like this: Basically `restic_backup.sh` will append a summary line of the last backup to a user-owned file (the user running your OS's desktop environment) in a fire-and-forget fashion. Then the user has a process that reads this and forward each line as a new message to the desktop environment in use.
+Therefore, this project provides a lightweight solution for desktop notifications that works like this: Basically `restic_backup.sh` will append a summary line of the last backup to a user-owned file (the user running your OS's desktop environment) in a fire-and-forget fashion. Then the user has a process that reads this and forward each line as a new message to the desktop environment in use.
 
 To set desktop notifications up:
 1. Create a special FIFO file as your desktop user:
@@ -461,7 +461,7 @@ To set desktop notifications up:
 	```
 1. Create a listener on the notification queue file that forwards to desktop notifications
    * Linux auto start + cross-platform notifier / notify-send
-      * [notification-queue-notifier](https://github.com/gerardbosch/dotfiles/blob/ddc1491056822eab45dedd131f1946308ef62135/home/bin/notification-queue-notifier)
+      * [notification-queue-notifier](https://github.com/gerardbosch/dotfiles/blob/2130d54daa827e7f885abac0d4f10b6f67d28ad3/home/bin/notification-queue-notifier)
       * [notification-queue.desktop](https://github.com/gerardbosch/dotfiles-linux/blob/ea0f75bfd7a356945544ecaa42a2fc35c9fab3a1/home/.config/autostart/notification-queue.desktop)
    * macOS auto start + [terminal-notifier](https://github.com/julienXX/terminal-notifier)
       * [notification-queue-notifier.sh](https://github.com/erikw/dotfiles/blob/8a942defe268292200b614951cdf433ddccf7170/bin/notification-queue-notifier.sh)
@@ -554,7 +554,7 @@ $ source /etc/restic/default.env.sh
 $ bash -x /bin/restic_backup.sh
 ```
 
-To debug smaller portions of of the backup script, insert these lines at the top and bottom of the relevant code portions e.g.:
+To debug smaller portions of the backup script, insert these lines at the top and bottom of the relevant code portions e.g.:
 
 ```bash
 set -x

--- a/README.md
+++ b/README.md
@@ -456,7 +456,6 @@ To set desktop notifications up:
 	```
 1. In your profile, e.g. `/etc/restic/default.sh`, set:
 	```bash
-	RESTIC_NOTIFY_BACKUP_STATS=true
 	RESTIC_BACKUP_NOTIFICATION_FILE=/home/user/.cache/notification-queue
 	```
 1. Create a listener on the notification queue file that forwards to desktop notifications

--- a/README.md
+++ b/README.md
@@ -442,9 +442,9 @@ To create a different backup and use you can do:
 # restic_backup.sh
 ```
 
-### Optional (enabled): Summary stats log
+### Optional: Summary stats log
 
-Enabled by default but can be disabled (opt-out) by setting its env variable empty: `RESTIC_BACKUP_STATS_DIR=` either on a specific profile, or on the global environment file (default: `$INSTALL_PREFIX/var/log/restic-automatic-backup-scheduler/`).
+When enabled, it will write to a CSV log file the stats after each backup. Can be enabled by uncommenting its env variable (`RESTIC_BACKUP_STATS_DIR`) on the global environment file or defining it on a specific profile.
 
 The stats log (as well as) the desktop notifications incur in an additional run of `restic snapshots` and `restic diff`. This execution is shared with the notifications (no extra run).
 

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -49,6 +49,29 @@ warn_on_missing_envvars() {
 	fi
 }
 
+# Log the backup summary stats to a CSV file
+logBackupStatsCsv() {
+	local added="$1" removed="$2" snapSize="$3"
+	local logFile="${RESTIC_BACKUP_STATS_DIR}/$(date '+%Y')-stats.log.csv"
+	test -e "$logFile" || install -D -m 0644 <(echo "Date, Added, Removed, Snapshot size") "$logFile"
+	# DEV-NOTE: using `ex` due `sed` inconsistencies (GNU vs. BSD) and `awk` cannot edit in-place. `ex` does a good job
+	printf '1a\n%s\n.\nwq\n' "$(date '+%F %H:%M:%S'), ${added}, ${removed}, ${snapSize}" | ex "$logFile"
+}
+
+# Notify the backup summary stats to the user
+notifyBackupStats() {
+	local statsMsg="$1"
+	if [ -w "$RESTIC_BACKUP_NOTIFICATION_FILE" ]; then
+		echo "$statsMsg" >> "$RESTIC_BACKUP_NOTIFICATION_FILE"
+	else
+		echo "[WARN] Couldn't write to the backup notification file. File not found or not writable: ${RESTIC_BACKUP_NOTIFICATION_FILE}"
+	fi
+}
+
+# ------------
+# === Main ===
+# ------------
+
 assert_envvars \
 	RESTIC_BACKUP_PATHS RESTIC_BACKUP_TAG \
 	RESTIC_BACKUP_EXCLUDE_FILE RESTIC_BACKUP_EXTRA_ARGS RESTIC_REPOSITORY RESTIC_VERBOSITY_LEVEL \
@@ -138,23 +161,21 @@ wait $!
 
 echo "Backup & cleaning is done."
 
-# (optionally) Notify about backup summary stats.
-if [ "$RESTIC_NOTIFY_BACKUP_STATS" = true ]; then
-	if [ -w "$RESTIC_BACKUP_NOTIFICATION_FILE" ]; then
-		echo 'Notifications are enabled: Silently computing backup summary stats...'
+# (optional) Compute backup summary stats
+if [[ -n "$RESTIC_BACKUP_STATS_DIR" || -n "$RESTIC_BACKUP_NOTIFICATION_FILE" ]]; then
+	echo 'Silently computing backup summary stats...'
+	latest_snapshot_diff=$(restic snapshots --tag "$RESTIC_BACKUP_TAG" --latest 2 --compact \
+		| grep -Ei "^[abcdef0-9]{8} " \
+		| awk '{print $1}' \
+		| tail -2 \
+		| tr '\n' ' ' \
+		| xargs restic diff)
+	added=$(echo "$latest_snapshot_diff" | grep -i 'added:' | awk '{print $2 " " $3}')
+	removed=$(echo "$latest_snapshot_diff" | grep -i 'removed:' | awk '{print $2 " " $3}')
+	snapshot_size=$(restic stats latest --tag "$RESTIC_BACKUP_TAG" | grep -i 'total size:' | cut -d ':' -f2 | xargs)  # xargs acts as trim
+	statsMsg="Added: ${added}. Removed: ${removed}. Snap size: ${snapshot_size}"
 
-		snapshot_size=$(restic stats latest --tag "$RESTIC_BACKUP_TAG" | grep -i 'total size:' | cut -d ':' -f2 | xargs)  # xargs acts as trim
-		latest_snapshot_diff=$(restic snapshots --tag "$RESTIC_BACKUP_TAG" --latest 2 --compact \
-			| grep -Ei "^[abcdef0-9]{8} " \
-			| awk '{print $1}' \
-			| tail -2 \
-			| tr '\n' ' ' \
-			| xargs restic diff)
-        added=$(echo "$latest_snapshot_diff" | grep -i 'added:' | awk '{print $2 " " $3}')
-        removed=$(echo "$latest_snapshot_diff" | grep -i 'removed:' | awk '{print $2 " " $3}')
-
-		echo "Added: ${added}. Removed: ${removed}. Snap size: ${snapshot_size}" >> "$RESTIC_BACKUP_NOTIFICATION_FILE"
-	else
-		echo "[WARN] Couldn't write the backup summary stats. File not found or not writable: ${RESTIC_BACKUP_NOTIFICATION_FILE}"
-	fi
+	echo "$statsMsg"
+	test -n "$RESTIC_BACKUP_STATS_DIR"         && logBackupStatsCsv "$added" "$removed" "$snapshot_size"
+	test -n "$RESTIC_BACKUP_NOTIFICATION_FILE" && notifyBackupStats "$statsMsg"
 fi

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -173,7 +173,7 @@ if [[ -n "$RESTIC_BACKUP_STATS_DIR" || -n "$RESTIC_BACKUP_NOTIFICATION_FILE" ]];
 	added=$(echo "$latest_snapshot_diff" | grep -i 'added:' | awk '{print $2 " " $3}')
 	removed=$(echo "$latest_snapshot_diff" | grep -i 'removed:' | awk '{print $2 " " $3}')
 	snapshot_size=$(restic stats latest --tag "$RESTIC_BACKUP_TAG" | grep -i 'total size:' | cut -d ':' -f2 | xargs)  # xargs acts as trim
-	snapshotId=$(echo $latest_snapshots | cut -d ' ' -f2)
+	snapshotId=$(echo "$latest_snapshots" | cut -d ' ' -f2)
 	statsMsg="Added: ${added}. Removed: ${removed}. Snap size: ${snapshot_size}"
 
 	echo "$statsMsg"

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -52,7 +52,8 @@ warn_on_missing_envvars() {
 # Log the backup summary stats to a CSV file
 logBackupStatsCsv() {
 	local snapId="$1" added="$2" removed="$3" snapSize="$4"
-	local logFile="${RESTIC_BACKUP_STATS_DIR}/$(date '+%Y')-stats.log.csv"
+	local logFile
+	logFile="${RESTIC_BACKUP_STATS_DIR}/$(date '+%Y')-stats.log.csv"
 	test -e "$logFile" || install -D -m 0644 <(echo "Date, Snapshot ID, Added, Removed, Snapshot size") "$logFile"
 	# DEV-NOTE: using `ex` due `sed` inconsistencies (GNU vs. BSD) and `awk` cannot edit in-place. `ex` does a good job
 	printf '1a\n%s\n.\nwq\n' "$(date '+%F %H:%M:%S'), ${snapId}, ${added}, ${removed}, ${snapSize}" | ex "$logFile"

--- a/etc/restic/_global.env.sh
+++ b/etc/restic/_global.env.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=sh
 
-# Global envionment variables
+# Global environment variables
 # These variables are sourced FIRST, and any values inside of *.env.sh files for
 # specific configurations will override if also defined there.
 

--- a/etc/restic/_global.env.sh
+++ b/etc/restic/_global.env.sh
@@ -30,6 +30,8 @@ export RESTIC_BACKUP_EXTRA_ARGS=
 # Override this value in a profile if needed.
 export RESTIC_VERBOSITY_LEVEL=0
 
-# (optional) Desktop notifications. See restic_backup.sh for details on how to set this up.
-export RESTIC_NOTIFY_BACKUP_STATS=false
+# Backup summary stats log: snapshot size, etc. (empty/unset won't log)
+export RESTIC_BACKUP_STATS_DIR="$INSTALL_PREFIX/var/log/restic-automatic-backup-scheduler"
+
+# (optional) Desktop notifications. See README and restic_backup.sh for details on how to set this up (empty/unset means disabled)
 export RESTIC_BACKUP_NOTIFICATION_FILE=

--- a/etc/restic/_global.env.sh
+++ b/etc/restic/_global.env.sh
@@ -30,8 +30,8 @@ export RESTIC_BACKUP_EXTRA_ARGS=
 # Override this value in a profile if needed.
 export RESTIC_VERBOSITY_LEVEL=0
 
-# Backup summary stats log: snapshot size, etc. (empty/unset won't log)
-export RESTIC_BACKUP_STATS_DIR="$INSTALL_PREFIX/var/log/restic-automatic-backup-scheduler"
+# (optional, uncomment to enable) Backup summary stats log: snapshot size, etc. (empty/unset won't log)
+#export RESTIC_BACKUP_STATS_DIR="$INSTALL_PREFIX/var/log/restic-automatic-backup-scheduler"
 
 # (optional) Desktop notifications. See README and restic_backup.sh for details on how to set this up (empty/unset means disabled)
 export RESTIC_BACKUP_NOTIFICATION_FILE=


### PR DESCRIPTION
I was missing to be able to track how the backup repo grows, and finally came up with a log to persist what desktop notification shows after the backup (many times I miss the notification and don't realized if I unconsciously added heavy files to the home backup).

When something gets added unintentionally to the backup I usually check/update the `~/.backup_exclude.txt` and manually run `sudo resticw forget --prune <offending snapshot ID>`. The stats log will help to better track these situations.

The stats log feature could be disabled (opt-out) by setting empty the new environment variable `$RESTIC_BACKUP_STATS_DIR`.

The log records the added, removed and snapshot size after each backup to a CSV log. This is how it looks:

```console
❯ cat /var/log/restic-automatic-backup-scheduler/2023-stats.log.csv    
Date, Snapshot ID, Added, Removed, Snapshot size
2023-12-11 23:05:00, fe91dd73, 3.383 MiB, 3.375 MiB, 8.042 GiB
2023-12-11 22:27:27, a3fa2de3, 2.413 MiB, 2.443 MiB, 8.042 GiB
2023-12-11 21:37:27, e414fb73, 4.285 MiB, 4.265 MiB, 8.042 GiB

❯ csvlook /var/log/restic-automatic-backup-scheduler/2023-stats.log.csv
|                Date |  Snapshot ID |  Added     |  Removed   |  Snapshot size |
| ------------------- | ------------ | ---------- | ---------- | -------------- |
| 2023-12-11 23:05:00 |  fe91dd73    |  3.383 MiB |  3.375 MiB |  8.042 GiB     |
| 2023-12-11 22:27:27 |  a3fa2de3    |  2.413 MiB |  2.443 MiB |  8.042 GiB     |
| 2023-12-11 21:37:27 |  e414fb73    |  4.285 MiB |  4.265 MiB |  8.042 GiB     |
```

Why a CSV? Just to avoid to fill a file with the same text message on each line. I thought on simply adding a header and just write the data, not the full message each time. New records are prepended in the log, the latest backup sits below the header (descending order), easy to inspect.

Organized with yearly file, e.g. `2023-stats.log.csv`