### PR TITLE
fix: Change INSTALL_PREFIX placeholder notation to templating notation

### DIFF
--- a/Library/LaunchAgents/com.github.erikw.restic-backup.plist
+++ b/Library/LaunchAgents/com.github.erikw.restic-backup.plist
@@ -12,12 +12,12 @@
 		<array>
 			<string>/bin/bash</string>
 			<string>-c</string>
-			<string>source $INSTALL_PREFIX/etc/restic/default.env.sh &amp;&amp; $INSTALL_PREFIX/bin/restic_backup.sh >>$HOME/$LOG_OUT 2>>$HOME/$LOG_ERR</string>
+			<string>source {{ INSTALL_PREFIX }}/etc/restic/default.env.sh &amp;&amp; {{ INSTALL_PREFIX }}/bin/restic_backup.sh >>$HOME/$LOG_OUT 2>>$HOME/$LOG_ERR</string>
 		</array>
 		<key>EnvironmentVariables</key>
 		<dict>
 			<key>PATH</key>
-			<string>$INSTALL_PREFIX/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+			<string>{{ INSTALL_PREFIX }}/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
 			<key>LOG_OUT</key>
 			<string>/Library/Logs/restic/backup_stdout.log</string>
 			<key>LOG_ERR</key>

--- a/Library/LaunchAgents/com.github.erikw.restic-check.plist
+++ b/Library/LaunchAgents/com.github.erikw.restic-check.plist
@@ -8,12 +8,12 @@
 		<array>
 			<string>/bin/bash</string>
 			<string>-c</string>
-			<string>source $INSTALL_PREFIX/etc/restic/default.env.sh &amp;&amp; $INSTALL_PREFIX/bin/restic_check.sh >>$HOME/$LOG_OUT 2>>$HOME/$LOG_ERR</string>
+			<string>source {{ INSTALL_PREFIX }}/etc/restic/default.env.sh &amp;&amp; {{ INSTALL_PREFIX }}/bin/restic_check.sh >>$HOME/$LOG_OUT 2>>$HOME/$LOG_ERR</string>
 		</array>
 		<key>EnvironmentVariables</key>
 		<dict>
 			<key>PATH</key>
-			<string>$INSTALL_PREFIX/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+			<string>{{ INSTALL_PREFIX }}/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
 			<key>LOG_OUT</key>
 			<string>/Library/Logs/restic/check_stdout.log</string>
 			<key>LOG_ERR</key>

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 #### Notes ####################################################################
 # This build process is done in three stages (out-of-source build):
 # 1. copy source files to the local build directory.
-# 2. build dir: replace the string "$INSTALL_PREFIX" with the value of $PREFIX
+# 2. build dir: replace the string "{{ INSTALL_PREFIX }}" with the value of $PREFIX
 # 3. install files from the build directory to the target directory.
 #
 # Why this dance?
 # * To fully support that a user can install this project to a custom path e.g.
 #   $(PREFIX=/usr/local make install), we need to modify the files that refer
 #   to other files on disk. We do this by having a placeholder
-#   "$INSTALL_PREFIX"  that is substituted with the value of $PREFIX when
+#   "{{ INSTALL_PREFIX }}"  that is substituted with the value of $PREFIX when
 #   installed.
 # * We don't want to modify the files that are controlled by git, thus let's
 #   copy them to a build directory and then modify.
@@ -57,7 +57,7 @@ LAUNCHAGENT_CHECK			= com.github.erikw.restic-check
 LAUNCHAGENT_TARGET_BACKUP	= gui/$(UID)/$(LAUNCHAGENT_BACKUP)
 LAUNCHAGENT_TARGET_CHECK	= gui/$(UID)/$(LAUNCHAGENT_CHECK)
 
-# What to substitute $INSTALL_PREFIX in sources to.
+# What to substitute {{ INSTALL_PREFIX }} in sources to.
 # This can be useful to set to empty on commandline when building e.g. an AUR
 # package in a separate build directory (PREFIX).
 INSTALL_PREFIX := $(PREFIX)
@@ -192,11 +192,11 @@ install-targets-schedtask: $(BUILD_DIR_SCHEDTASK)/$(SCHEDTASK_INSTALL)
 uninstall-targets-schedtask: $(BUILD_DIR_SCHEDTASK)/$(SCHEDTASK_UNINSTALL)
 	test $(CUR_OS) != Windows || ./$<
 
-# Copies sources to build directory & replace "$INSTALL_PREFIX".
+# Copies sources to build directory & replace "{{ INSTALL_PREFIX }}".
 $(BUILD_DIR)/% : %
 	@${MKDIR_PARENTS} $@
 	cp $< $@
-	sed -i.bak -e 's|$$INSTALL_PREFIX|$(INSTALL_PREFIX)|g' $@; rm $@.bak
+	sed -i.bak -e 's|{{ INSTALL_PREFIX }}|$(INSTALL_PREFIX)|g' $@; rm $@.bak
 
 # Install destination script files.
 $(DEST_DIR_SCRIPT)/%: $(BUILD_DIR_SCRIPT)/%

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ $ git clone https://github.com/erikw/restic-automatic-backup-scheduler.git && cd
 
 Make a quick search-and-replace in the source files:
 ```console
-$ find etc bin -type f -exec sed -i.bak -e 's|{{ INSTALL_PREFIX }}||g' {} \; -exec rm {}.bak \;
+$ find . -type f -exec sed -i.bak -e 's|{{ INSTALL_PREFIX }}||g' {} \; -exec rm {}.bak \;
 ```
 and you should now see that all files have been changed like e.g.
 ```diff
@@ -483,7 +483,7 @@ We want to be aware when the automatic backup fails, so we can fix it. Since my 
 Put this file in `/bin`:
 * `systemd-email`: Sends email using sendmail(1). This script also features time-out for not spamming Gmail servers and getting my account blocked.
 
-Put this files in `/etc/systemd/system/`:
+Put this file in `/etc/systemd/system/`:
 * `status-email-user@.service`: A service that can notify you via email when a systemd service fails. Edit the target email address in this file.
 
 Now edit `restic-backup@.service` and `status-email-user@.service` to call this service failure.

--- a/README.md
+++ b/README.md
@@ -308,17 +308,17 @@ $ git clone https://github.com/erikw/restic-automatic-backup-scheduler.git && cd
 
 Make a quick search-and-replace in the source files:
 ```console
-$ find etc bin -type f -exec sed -i.bak -e 's|$INSTALL_PREFIX||g' {} \; -exec rm {}.bak \;
+$ find etc bin -type f -exec sed -i.bak -e 's|{{ INSTALL_PREFIX }}||g' {} \; -exec rm {}.bak \;
 ```
 and you should now see that all files have been changed like e.g.
 ```diff
--export RESTIC_PASSWORD_FILE="$INSTALL_PREFIX/etc/restic/pw.txt"
+-export RESTIC_PASSWORD_FILE="{{ INSTALL_PREFIX }}/etc/restic/pw.txt"
 +export RESTIC_PASSWORD_FILE="/etc/restic/pw.txt"
 ```
 
-Why? The OS specific TL;DR setups above all use the [Makefile](Makefile) or a package manager to install these files. The placeholder string `$INSTALL_PREFIX` is in the source files for portability reasons, so that the Makefile can support all different operating systems. `make` users can set a different `$PREFIX` when installing like `PREFIX=/usr/local make install-systemd`.
+Why? The OS specific TL;DR setups above all use the [Makefile](Makefile) or a package manager to install these files. The placeholder string `{{ INSTALL_PREFIX }}` is in the source files for portability reasons, so that the Makefile can support all different operating systems. `make` users can set a different `$PREFIX` when installing like `PREFIX=/usr/local make install-systemd`.
 
-In this detailed manual setup we will copy all files manually to `/etc`and `/bin`. Thus we need to remove the placeholder string `$INSTALL_PREFIX` in the source files as a first step.
+In this detailed manual setup we will copy all files manually to `/etc`and `/bin`. Thus, we need to remove the placeholder string `{{ INSTALL_PREFIX }}` in the source files as a first step.
 
 
 #### 1. Create Backblaze B2 Account, Bucket and Keys

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ $ git clone https://github.com/erikw/restic-automatic-backup-scheduler.git && cd
 
 Make a quick search-and-replace in the source files:
 ```console
-$ find . -type f -exec sed -i.bak -e 's|{{ INSTALL_PREFIX }}||g' {} \; -exec rm {}.bak \;
+$ find bin etc usr Library ScheduledTask -type f -exec sed -i.bak -e 's|{{ INSTALL_PREFIX }}||g' {} \; -exec rm {}.bak \;
 ```
 and you should now see that all files have been changed like e.g.
 ```diff

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Put this file in `/bin`:
 * `systemd-email`: Sends email using sendmail(1). This script also features time-out for not spamming Gmail servers and getting my account blocked.
 
 Put this file in `/etc/systemd/system/`:
-* `status-email-user@.service`: A service that can notify you via email when a systemd service fails. Edit the target email address in this file.
+* `status-email-user@.service`: A service that can notify you via email when a systemd service fails. Edit the target email address in this file, and replace or remove `{{ INSTALL_PREFIX }}` according to your installation.
 
 Now edit `restic-backup@.service` and `status-email-user@.service` to call this service failure.
 ```

--- a/ScheduledTask/install.ps1
+++ b/ScheduledTask/install.ps1
@@ -9,11 +9,11 @@
 
 
 # Install restic_backup.sh
-$action = New-ScheduledTaskAction -Execute "$(scoop prefix git)\git-bash.exe" -Argument '-l -c "source $INSTALL_PREFIX/etc/restic/default.env.sh && $INSTALL_PREFIX/bin/restic_backup.sh"'
+$action = New-ScheduledTaskAction -Execute "$(scoop prefix git)\git-bash.exe" -Argument '-l -c "source {{ INSTALL_PREFIX }}/etc/restic/default.env.sh && {{ INSTALL_PREFIX }}/bin/restic_backup.sh"'
 $trigger =  New-ScheduledTaskTrigger -Daily -At 7pm
 Register-ScheduledTask -Action $action -Trigger $trigger -TaskName "restic_backup" -Description "Daily backup to B2 with restic."
 
 # Install restic_check.sh
-$action = New-ScheduledTaskAction -Execute "$(scoop prefix git)\git-bash.exe" -Argument '-l -c "source $INSTALL_PREFIX/etc/restic/default.env.sh && $INSTALL_PREFIX/bin/restic_check.sh"'
+$action = New-ScheduledTaskAction -Execute "$(scoop prefix git)\git-bash.exe" -Argument '-l -c "source {{ INSTALL_PREFIX }}/etc/restic/default.env.sh && {{ INSTALL_PREFIX }}/bin/restic_check.sh"'
 $trigger =  New-ScheduledTaskTrigger  -Weekly -WeeksInterval 4 -DaysOfWeek Sunday -At 8pm -RandomDelay 128
 Register-ScheduledTask -Action $action -Trigger $trigger -TaskName "restic_check" -Description "Check B2 backups with restic."

--- a/bin/cron_mail
+++ b/bin/cron_mail
@@ -5,7 +5,7 @@
 # Why? Because of FreeBSD the system cron uses sendmail, and I want to use ssmtp.
 # Make your crontab files like:
 #SHELL=/bin/sh
-#PATH=/etc:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/sbin:$INSTALL_PREFIX/bin
+#PATH=/etc:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/sbin:{{ INSTALL_PREFIX }}/bin
 #@daily       root    cron_mail freebsd-update cron
 
 mail_target=root

--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -29,7 +29,7 @@ assert_envvars() {
 	local varnames=("$@")
 	for varname in "${varnames[@]}"; do
 		if [ -z ${!varname+x} ]; then
-			printf "%s must be set for this script to work.\n\nDid you forget to source a $INSTALL_PREFIX/etc/restic/*.env.sh profile in the current shell before executing this script?\n" "$varname" >&2
+			printf "%s must be set for this script to work.\n\nDid you forget to source a {{ INSTALL_PREFIX }}/etc/restic/*.env.sh profile in the current shell before executing this script?\n" "$varname" >&2
 			exit 1
 		fi
 	done
@@ -97,7 +97,7 @@ B2_ARG=
 [ -z "${B2_CONNECTIONS+x}" ] || B2_ARG=(--option b2.connections="$B2_CONNECTIONS")
 
 # If you need to run some commands before performing the backup; create this file, put them there and make the file executable.
-PRE_SCRIPT="${INSTALL_PREFIX}/etc/restic/pre_backup.sh"
+PRE_SCRIPT="{{ INSTALL_PREFIX }}/etc/restic/pre_backup.sh"
 test -x "$PRE_SCRIPT" && "$PRE_SCRIPT"
 
 # Set up exclude files: global + path-specific ones

--- a/bin/restic_check.sh
+++ b/bin/restic_check.sh
@@ -21,7 +21,7 @@ assert_envvars() {
 	local varnames=("$@")
 	for varname in "${varnames[@]}"; do
 		if [ -z ${!varname+x} ]; then
-			printf "%s must be set for this script to work.\n\nDid you forget to source a $INSTALL_PREFIX/etc/restic/*.env.sh profile in the current shell before executing this script?\n" "$varname" >&2
+			printf "%s must be set for this script to work.\n\nDid you forget to source a {{ INSTALL_PREFIX }}/etc/restic/*.env.sh profile in the current shell before executing this script?\n" "$varname" >&2
 			exit 1
 		fi
 	done

--- a/bin/resticw
+++ b/bin/resticw
@@ -148,7 +148,7 @@ eval "$(docopt "$@")"
 
 # Exit on error, unbound variable, pipe error
 set -euo pipefail
-ENV_DIR=$INSTALL_PREFIX/etc/restic
+ENV_DIR="{{ INSTALL_PREFIX }}/etc/restic"
 
 ERR_NO_SUCH_PROFILE=2
 ERR_PROFILE_NO_READ_PERM=3

--- a/etc/cron.d/restic
+++ b/etc/cron.d/restic
@@ -1,13 +1,13 @@
 SHELL=/bin/sh
-PATH=/etc:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin/:$INSTALL_PREFIX/bin/
+PATH=/etc:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin/:{{ INSTALL_PREFIX }}/bin/
 # Order of crontab fields
 # minute        hour    mday    month   wday    command
 # Reference: https://www.freebsd.org/doc/handbook/configtuning-cron.html
 # Reference: crontab(5).
 
-@midnight	root	. $INSTALL_PREFIX/etc/restic/default.env.sh && restic_backup.sh
-@monthly	root	. $INSTALL_PREFIX/etc/restic/default.env.sh && restic_check.sh
+@midnight	root	. {{ INSTALL_PREFIX }}/etc/restic/default.env.sh && restic_backup.sh
+@monthly	root	. {{ INSTALL_PREFIX }}/etc/restic/default.env.sh && restic_check.sh
 
 # Email notification version. Make sure bin/cron_mail is in the above $PATH
-#@midnight	root	. $INSTALL_PREFIX/etc/restic/default.env.sh && cron_mail restic_backup.sh
-#@monthly	root	. $INSTALL_PREFIX/etc/restic/default.env.sh && cron_mail restic_check.sh
+#@midnight	root	. {{ INSTALL_PREFIX }}/etc/restic/default.env.sh && cron_mail restic_backup.sh
+#@monthly	root	. {{ INSTALL_PREFIX }}/etc/restic/default.env.sh && cron_mail restic_check.sh

--- a/etc/restic/_global.env.sh
+++ b/etc/restic/_global.env.sh
@@ -10,9 +10,9 @@
 
 
 # The restic repository encryption key
-export RESTIC_PASSWORD_FILE="$INSTALL_PREFIX/etc/restic/pw.txt"
+export RESTIC_PASSWORD_FILE="{{ INSTALL_PREFIX }}/etc/restic/pw.txt"
 # The global restic exclude file
-export RESTIC_BACKUP_EXCLUDE_FILE="$INSTALL_PREFIX/etc/restic/backup_exclude.txt"
+export RESTIC_BACKUP_EXCLUDE_FILE="{{ INSTALL_PREFIX }}/etc/restic/backup_exclude.txt"
 
 # Backblaze B2 credentials keyID & applicationKey pair.
 # Restic environment variables are documented at https://restic.readthedocs.io/en/latest/040_backup.html#environment-variables
@@ -31,7 +31,7 @@ export RESTIC_BACKUP_EXTRA_ARGS=
 export RESTIC_VERBOSITY_LEVEL=0
 
 # (optional, uncomment to enable) Backup summary stats log: snapshot size, etc. (empty/unset won't log)
-#export RESTIC_BACKUP_STATS_DIR="$INSTALL_PREFIX/var/log/restic-automatic-backup-scheduler"
+#export RESTIC_BACKUP_STATS_DIR="{{ INSTALL_PREFIX }}/var/log/restic-automatic-backup-scheduler"
 
 # (optional) Desktop notifications. See README and restic_backup.sh for details on how to set this up (empty/unset means disabled)
 export RESTIC_BACKUP_NOTIFICATION_FILE=

--- a/etc/restic/default.env.sh
+++ b/etc/restic/default.env.sh
@@ -12,7 +12,7 @@
 #  $ restic --repo ... --password-file ...
 
 # shellcheck source=etc/restic/_global.env.sh
-. "$INSTALL_PREFIX/etc/restic/_global.env.sh"
+. "{{ INSTALL_PREFIX }}/etc/restic/_global.env.sh"
 
 # Envvars below will override those in _global.env.sh if present.
 

--- a/usr/lib/systemd/system/nm-unmetered-connection.service
+++ b/usr/lib/systemd/system/nm-unmetered-connection.service
@@ -3,4 +3,4 @@ Description=Check if the current NetworkManager connection is metered
 
 [Service]
 Type=oneshot
-ExecStart=$INSTALL_PREFIX/bin/nm-unmetered-connection.sh
+ExecStart={{ INSTALL_PREFIX }}/bin/nm-unmetered-connection.sh

--- a/usr/lib/systemd/system/restic-backup@.service
+++ b/usr/lib/systemd/system/restic-backup@.service
@@ -14,4 +14,4 @@ Environment="HOME=/root"
 # pipefail: so that redirecting stderr from the script to systemd-cat does not hide the failed command from OnFailure above.
 # Random sleep (in seconds): in the case of multiple backup profiles. Many restic instances started at the same time could case high load or network bandwith usage.
 # `systemd-cat` allows showing the restic output to the systemd journal
-ExecStart=/bin/bash -c 'set -o pipefail; ps cax | grep -q restic && sleep $(shuf -i 0-300 -n 1); source $INSTALL_PREFIX/etc/restic/%I.env.sh && $INSTALL_PREFIX/bin/restic_backup.sh 2>&1 | systemd-cat'
+ExecStart=/bin/bash -c 'set -o pipefail; ps cax | grep -q restic && sleep $(shuf -i 0-300 -n 1); source {{ INSTALL_PREFIX }}/etc/restic/%I.env.sh && {{ INSTALL_PREFIX }}/bin/restic_backup.sh 2>&1 | systemd-cat'

--- a/usr/lib/systemd/system/restic-check@.service
+++ b/usr/lib/systemd/system/restic-check@.service
@@ -12,4 +12,4 @@ Type=simple
 Nice=10
 # pipefail: so that redirecting stderr from the script to systemd-cat does not hide the failed command from OnFailure above.
 # `systemd-cat`: allows showing the restic output to the systemd journal
-ExecStart=/bin/bash -c 'set -o pipefail; source $INSTALL_PREFIX/etc/restic/%I.env.sh && $INSTALL_PREFIX/bin/restic_check.sh 2>&1 | systemd-cat'
+ExecStart=/bin/bash -c 'set -o pipefail; source {{ INSTALL_PREFIX }}/etc/restic/%I.env.sh && {{ INSTALL_PREFIX }}/bin/restic_check.sh 2>&1 | systemd-cat'

--- a/usr/lib/systemd/system/status-email-user@.service
+++ b/usr/lib/systemd/system/status-email-user@.service
@@ -6,6 +6,6 @@ Description=Send status email for %i to user
 
 [Service]
 Type=oneshot
-ExecStart=$INSTALL_PREFIX/bin/systemd-email abc@gmail.com %i
+ExecStart={{ INSTALL_PREFIX }}/bin/systemd-email abc@gmail.com %i
 User=root
 Group=systemd-journal


### PR DESCRIPTION
The former shell notation `$INSTALL_PREFIX` could result confusing. As
this is a placeholder that's replaced by `make`, we switch it to a
template notation `{{ INSTALL_PREFIX }}`.

Also, fixes one occurrence of the placeholder in `restic_backup.sh` not replaced (was using `${}` notation and not replaced by `sed`).