### PR TITLE
Check that there are enough snapshots before diff

### DIFF
--- a/bin/restic_backup.sh
+++ b/bin/restic_backup.sh
@@ -181,16 +181,9 @@ if [[ -n "$RESTIC_BACKUP_STATS_DIR" || -n "$RESTIC_BACKUP_NOTIFICATION_FILE" ]];
 		snapshot_size=$(restic stats latest --tag "$RESTIC_BACKUP_TAG" | grep -i 'total size:' | cut -d ':' -f2 | xargs)  # xargs acts as trim
 		snapshotId=$(echo "$latest_snapshots" | cut -d ' ' -f2)
 		statsMsg="Added: ${added}. Removed: ${removed}. Snap size: ${snapshot_size}"
+
+		echo "$statsMsg"
+		test -n "$RESTIC_BACKUP_STATS_DIR"         && logBackupStatsCsv "$snapshotId" "$added" "$removed" "$snapshot_size"
+		test -n "$RESTIC_BACKUP_NOTIFICATION_FILE" && notifyBackupStats "$statsMsg"
 	fi
-
-	latest_snapshot_diff=$(echo "$latest_snapshots"	| xargs restic diff)
-	added=$(echo "$latest_snapshot_diff" | grep -i 'added:' | awk '{print $2 " " $3}')
-	removed=$(echo "$latest_snapshot_diff" | grep -i 'removed:' | awk '{print $2 " " $3}')
-	snapshot_size=$(restic stats latest --tag "$RESTIC_BACKUP_TAG" | grep -i 'total size:' | cut -d ':' -f2 | xargs)  # xargs acts as trim
-	snapshotId=$(echo "$latest_snapshots" | cut -d ' ' -f2)
-	statsMsg="Added: ${added}. Removed: ${removed}. Snap size: ${snapshot_size}"
-
-	echo "$statsMsg"
-	test -n "$RESTIC_BACKUP_STATS_DIR"         && logBackupStatsCsv "$snapshotId" "$added" "$removed" "$snapshot_size"
-	test -n "$RESTIC_BACKUP_NOTIFICATION_FILE" && notifyBackupStats "$statsMsg"
 fi


### PR DESCRIPTION
The first run after init'ing tends to cause a systemd failure due to not having enough snapshots for statistics.